### PR TITLE
feat: add multithreading

### DIFF
--- a/src/main/java/com/niton/render/Launcher.java
+++ b/src/main/java/com/niton/render/Launcher.java
@@ -32,8 +32,7 @@ public class Launcher {
 		JFrame frame = new JFrame();
 		frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
 		frame.setSize(420,360);
-		SwingRender r = new SwingRender();
-		r.setShader(shader);
+		SwingRender r = new SwingRender(shader);
 		frame.getContentPane().add(r);
 		frame.setVisible(true);
 

--- a/src/main/java/com/niton/render/Launcher.java
+++ b/src/main/java/com/niton/render/Launcher.java
@@ -5,6 +5,7 @@ import com.niton.reactj.Observer;
 import com.niton.reactj.ReactiveController;
 import com.niton.reactj.ReactiveProxy;
 import com.niton.reactj.mvc.Listener;
+import com.niton.render.RaymarchShader.RaymarchRuntime;
 import com.niton.render.ui.ReactableSettings;
 import com.niton.render.ui.RenderSettingUI;
 import com.niton.render.ui.SwingRender;
@@ -32,7 +33,7 @@ public class Launcher {
 		JFrame frame = new JFrame();
 		frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
 		frame.setSize(420,360);
-		SwingRender r = new SwingRender(shader);
+		SwingRender r = new SwingRender(shader, RaymarchRuntime::new);
 		frame.getContentPane().add(r);
 		frame.setVisible(true);
 

--- a/src/main/java/com/niton/render/Material.java
+++ b/src/main/java/com/niton/render/Material.java
@@ -82,31 +82,27 @@ public class Material {
 		return this;
 	}
 	final float[] pxl = new float[4];
-	private synchronized Vector3 uvMap(Vector2 surfaceUV, BufferedImage map) {
-		try {
-			map.getRaster().getPixel(
-					(int) ((map.getWidth() * surfaceUV.x)),
-					(int) ((map.getHeight() * surfaceUV.y)),
-					pxl);
-		}catch (Exception e){
-			e.printStackTrace();
-			System.exit(1);
-		}
-		return new Vector3(pxl).scl(1/255f);
+	private final Vector3 mapReadBuffer = new Vector3();
+	private Vector3 uvMap(Vector2 surfaceUV, BufferedImage map) {
+		map.getRaster().getPixel(
+				(int) ((map.getWidth() * surfaceUV.x)),
+				(int) ((map.getHeight() * surfaceUV.y)),
+				pxl);
+		return mapReadBuffer.set(pxl).scl(1/255f);
 	}
 
-	public synchronized Surface getPoint(Vector2 surface2UV) {
+	public Surface getPoint(Vector2 surface2UV) {
 		Surface sur = new Surface();
-		if(useTexture)
-			sur.albedo = uvMap(surface2UV, albedoMap);
-		if(useNormalMap)
-			sur.normal = uvMap(surface2UV,normalMap).sub(0.5f).scl(2).nor();
-		if(useHeightMap)
-			sur.depth = 1-uvMap(surface2UV, heightMap).x;
-		if(useAOMap)
-			sur.ao = uvMap(surface2UV,aoMap).x;
-		if(useMetallicMap)
-			sur.refect = uvMap(surface2UV,metallicMap).x;
+		if (useTexture)
+			sur.albedo.set(uvMap(surface2UV, albedoMap));
+		if (useNormalMap)
+			sur.normal.set(uvMap(surface2UV, normalMap).sub(0.5f).scl(2).nor());
+		if (useHeightMap)
+			sur.depth = 1 - uvMap(surface2UV, heightMap).x;
+		if (useAOMap)
+			sur.ao = uvMap(surface2UV, aoMap).x;
+		if (useMetallicMap)
+			sur.refect = uvMap(surface2UV, metallicMap).x;
 		return sur;
 	}
 }

--- a/src/main/java/com/niton/render/Material.java
+++ b/src/main/java/com/niton/render/Material.java
@@ -82,7 +82,7 @@ public class Material {
 		return this;
 	}
 	final float[] pxl = new float[4];
-	private Vector3 uvMap(Vector2 surfaceUV, BufferedImage map) {
+	private synchronized Vector3 uvMap(Vector2 surfaceUV, BufferedImage map) {
 		try {
 			map.getRaster().getPixel(
 					(int) ((map.getWidth() * surfaceUV.x)),
@@ -95,7 +95,7 @@ public class Material {
 		return new Vector3(pxl).scl(1/255f);
 	}
 
-	public Surface getPoint(Vector2 surface2UV) {
+	public synchronized Surface getPoint(Vector2 surface2UV) {
 		Surface sur = new Surface();
 		if(useTexture)
 			sur.albedo = uvMap(surface2UV, albedoMap);

--- a/src/main/java/com/niton/render/RaymarchShader.java
+++ b/src/main/java/com/niton/render/RaymarchShader.java
@@ -54,7 +54,7 @@ public class RaymarchShader implements SwingShader {
 	private static final Vector3 SKY_ALBEDO = new Vector3(0.1f,0.23f,0.6f);
 
 	//the disdance at which heightmaps are not applied anymore (LOD in the end of the day)
-	private static final float MAX_HMAP_DIST  = 10f;
+	private static final float MAX_HMAP_DIST  = 3f;
 
 	private static final Vector3 WHITE          = new Vector3(1,1,1);
 	private static final Vector3 FOG_COLOR            = new Vector3(WHITE).scl(0.6f);
@@ -180,7 +180,7 @@ public class RaymarchShader implements SwingShader {
 			//apply normal map
 			if(settings.useNormalMaps())
 				//broken for spheres, WELP, no idea why
-				applyNormalMap(hit, normal, surface);
+				applyNormalMap(normal, surface);
 
 
 			//offset for further ray casting
@@ -352,7 +352,7 @@ public class RaymarchShader implements SwingShader {
 	 * Applies the normal map to the normal of the surface (directly modifies the "normal" param)
 	 * @param normal normal to modify (and use to calculate)
 	 */
-	private void applyNormalMap(SurfaceHit hit, Vector3 normal, Surface surface) {
+	private void applyNormalMap(Vector3 normal, Surface surface) {
 		Vector3    base = new Vector3(0,0,1);
 		Quaternion q = new Quaternion().setFromCross(base, normal);
 		normal.set(q.transform(surface.normal)).nor();

--- a/src/main/java/com/niton/render/RenderingThread.java
+++ b/src/main/java/com/niton/render/RenderingThread.java
@@ -4,45 +4,44 @@ import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
 
 import java.awt.image.WritableRaster;
-import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 
-public class RenderingThread extends Thread {
-	private final SwingShader              shader;
+public class RenderingThread<R> extends Thread {
+	private final SwingShader<R>              shader;
+	private final R runtime;
 	private final BlockingQueue<PixelTask> taksQueue;
 	private final BlockingQueue<PixelTask>         completedPool;
 
-	public RenderingThread(SwingShader shader,
+	public RenderingThread(SwingShader<R> shader,
 	                       BlockingQueue<PixelTask> taksQueue,
 	                       BlockingQueue<PixelTask> completedPool,
-	                       ThreadGroup group) {
+	                       ThreadGroup group, R runtime) {
 		super(group,"Renderer");
 		this.shader        = shader;
 		this.taksQueue     = taksQueue;
 		this.completedPool = completedPool;
+		this.runtime       = runtime;
 	}
 
 
 	@Override
 	public void run() {
-		Vector3 output;
+		Vector2 uv = new Vector2();
+		Vector3 output = new Vector3();
 		while(true) {
-			PixelTask task;
 			try {
-				task = taksQueue.take();
-			} catch (InterruptedException e) {
-				e.printStackTrace();
-				break;
-			}
-			output = shader.render(task.uvCordinate);
-			output.scl(255);
+				PixelTask task = taksQueue.take();
 
-			task.output = new float[]{
-					Math.min(255, output.x),
-					Math.min(255, output.y),
-					Math.min(255, output.z)
-			};
-			try {
+
+				float ux = (float) task.x/task.raster.getWidth();
+				float uy = (float) task.y/task.raster.getHeight();
+				uv.set(ux,uy);
+				shader.render(uv,output,runtime);
+				output.scl(255);
+
+				task.output[0] = Math.min(255, output.x);
+				task.output[1] = Math.min(255, output.y);
+				task.output[2] = Math.min(255, output.z);
 				completedPool.put(task);
 			} catch (InterruptedException e) {
 				e.printStackTrace();
@@ -51,10 +50,9 @@ public class RenderingThread extends Thread {
 		}
 	}
 	public static class PixelTask  {
-		public Vector2        uvCordinate;
 		public int            x;
 		public int            y;
 		public WritableRaster raster;
-		public float[] output;
+		public final float[] output = new float[3];
 	}
 }

--- a/src/main/java/com/niton/render/RenderingThread.java
+++ b/src/main/java/com/niton/render/RenderingThread.java
@@ -1,0 +1,60 @@
+package com.niton.render;
+
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.math.Vector3;
+
+import java.awt.image.WritableRaster;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+
+public class RenderingThread extends Thread {
+	private final SwingShader              shader;
+	private final BlockingQueue<PixelTask> taksQueue;
+	private final BlockingQueue<PixelTask>         completedPool;
+
+	public RenderingThread(SwingShader shader,
+	                       BlockingQueue<PixelTask> taksQueue,
+	                       BlockingQueue<PixelTask> completedPool,
+	                       ThreadGroup group) {
+		super(group,"Renderer");
+		this.shader        = shader;
+		this.taksQueue     = taksQueue;
+		this.completedPool = completedPool;
+	}
+
+
+	@Override
+	public void run() {
+		Vector3 output;
+		while(true) {
+			PixelTask task;
+			try {
+				task = taksQueue.take();
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+				break;
+			}
+			output = shader.render(task.uvCordinate);
+			output.scl(255);
+
+			task.output = new float[]{
+					Math.min(255, output.x),
+					Math.min(255, output.y),
+					Math.min(255, output.z)
+			};
+			try {
+				completedPool.put(task);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+				break;
+			}
+		}
+	}
+	public static class PixelTask  {
+		public Vector2        uvCordinate;
+		public int            x;
+		public int            y;
+		public WritableRaster raster;
+		public float[] output;
+	}
+}

--- a/src/main/java/com/niton/render/SwingShader.java
+++ b/src/main/java/com/niton/render/SwingShader.java
@@ -3,16 +3,25 @@ package com.niton.render;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
 
-import java.awt.*;
-
-public interface SwingShader {
+/**
+ * A shader to calculate single pixels (ray-based)
+ * @param <R> type of the runtime
+ *
+ *           the runtime is used to store runtime variables this is needed for multi threading
+ */
+public interface SwingShader<R> {
 	/**
 	 * Calculates the color for a pixel on the screen based on a virtual 3D world
 	 * @param screenUV the poition of the pixel to color (on the screen) [0..1]
+	 * @param runtime
 	 * @return a vector3 [0..1] expressing the color of the pixel on said cord. x,y,z -> r,g,b (chads dont need alpha)
 	 */
-	Vector3 render(Vector2 screenUV);
-
+	default Vector3 render(Vector2 screenUV, R runtime){
+		Vector3 col = new Vector3();
+		render(screenUV, col, runtime);
+		return col;
+	}
+	void render(Vector2 screenUV,Vector3 result,R runtume);
 	/**
 	 * Tells the shader the size of the viewport before the rendering process
 	 */

--- a/src/main/java/com/niton/render/ui/SwingRender.java
+++ b/src/main/java/com/niton/render/ui/SwingRender.java
@@ -1,13 +1,19 @@
 package com.niton.render.ui;
 
 import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.math.Vector3;
+import com.niton.render.RenderingThread;
+import com.niton.render.RenderingThread.PixelTask;
 import com.niton.render.SwingShader;
 
 import javax.swing.*;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.image.WritableRaster;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * Uses a jpanel to render a shader onto it
@@ -15,43 +21,89 @@ import java.awt.image.WritableRaster;
  * (still useable as a jpanel if you want)
  */
 public class SwingRender extends JPanel {
-	//shader to render
-	private SwingShader shader;
+
+	private final ThreadGroup threadGroup;
+	private final SwingShader shader;
+	BufferedImage  img;
+	WritableRaster raster;
+	private final RenderingThread[]        threads;
+
+
+	//in this pool there are many PixelTask instances ready to be used
+	//this is to avoid retundant object initialization
+	private final Queue<PixelTask>         pixelTaskPool = new ArrayDeque<>();
+	private final BlockingQueue<PixelTask> completedTasks = new LinkedBlockingQueue<>();
+	//Threads get the tasks from here
+	private final BlockingQueue<PixelTask> taskQueue = new LinkedBlockingQueue<>(1024);
+
+	public SwingRender(SwingShader shader) {
+		this.shader = shader;
+		threadGroup = new ThreadGroup("Renderers");
+		int cores = Runtime.getRuntime().availableProcessors();
+		threads = new RenderingThread[cores];
+		for (int i  = 0;i<cores;i++){
+			threads[i] = new RenderingThread(shader,taskQueue,completedTasks,threadGroup);
+			threads[i].start();
+		}
+		threadGroup.setDaemon(true);
+		createPixelBuffer(1,1);
+	}
+
+	private void createPixelBuffer(int w,int h) {
+		img    = new BufferedImage(w,h,BufferedImage.TYPE_INT_RGB);
+		raster = img.getRaster();
+		while (pixelTaskPool.size()<Math.max(w*h,taskQueue.remainingCapacity())){
+			pixelTaskPool.add(new PixelTask());
+		}
+	}
+
+
 	@Override
 	protected void paintComponent(Graphics g) {
 		Graphics2D g2d = (Graphics2D) g;
-		if(shader == null) {
-			g.drawChars("NO SHADER".toCharArray(), 0, 9, 20, 10);
-			return;
-		}
 		int w = (int) g.getClipBounds().getWidth(), h = (int) g.getClipBounds().getHeight();
+		int dimens = w*h;
 
 		//i render to an buffered image. Why?
 		//* Its easy
 		//* you could straigt up save the image as JPEG/PNG
-		BufferedImage img = new BufferedImage(w,h,BufferedImage.TYPE_INT_RGB);
-		WritableRaster view = img.getRaster();
+		if(img.getWidth() != w || img.getHeight() != h)
+			createPixelBuffer(w,h);
 		shader.setDimension(w,h);
 		shader.frame();
+		System.out.println("w/h = "+w+"/"+h+" = "+w*h+" = "+pixelTaskPool.size()+" >= "+taskQueue.remainingCapacity());
 		for (int i = 0; i < w; i++) {
 			for (int y = 0; y < h; y++) {
 				//calculating UVs and interpreting the result of the shader
 				float ux = (float) i/w;
 				float uy = (float) y/h;
-				Vector3 col = shader.render(new Vector2(ux,uy));
-				col.scl(255);
-				view.setPixel(i,y,new float[]{
-						Math.min(255,col.x),
-						Math.min(255,col.y),
-						Math.min(255,col.z)
-				});
+				PixelTask task;
+				synchronized (pixelTaskPool) {
+					task = pixelTaskPool.poll();
+				}
+				task.uvCordinate = new Vector2(ux,uy);
+				task.x = i;
+				task.y = y;
+				task.raster = raster;
+				try {
+					taskQueue.put(task);
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+				}
 			}
 		}
 		//paint image to UI
+		for (int i = 0; i < dimens; i++) {
+			PixelTask completed;
+			try {
+				completed = completedTasks.take();
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+				break;
+			}
+			raster.setPixel(completed.x,completed.y,completed.output);
+			pixelTaskPool.add(completed);
+		}
 		g2d.drawImage(img,0,0,null);
-	}
-
-	public void setShader(SwingShader shader) {
-		this.shader = shader;
 	}
 }


### PR DESCRIPTION
Adds multithreading.
The rendering process is subdivided into PixelTasks. Each task contains the cordinates of a pixel and is pushed to a queue.

Rendering threads then consume this queue render the specific pixel and push the result into a "place onto screen" queue.

The last step is a thread whos task it is to consume the result queue and place the colors into a frame buffer

Depending on many factors you will experince a 20% to 20000% decrese in rendering time